### PR TITLE
fix: Prisma User.id as Int to match DB - fix 22P03 and 42883 errors

### DIFF
--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 model User {
-  id                  String          @id // Will be set manually as 9-digit number
+  id                  Int             @id // Matches backend users.id (SERIAL)
   username            String          @unique
   password            String
   role                String          @default("personal") // "personal" | "admin"
@@ -34,7 +34,7 @@ model User {
 
 model Collage {
   id             String   @id @default(cuid())
-  userId         String
+  userId         Int
   imageUrl       String // Path to the saved image file
   emotions       String? // JSON array of emotions: ["Angry", "Disgust", "Fear", "Happy", "Sad", "Surprise"]
   folder         String?  @default("Me")
@@ -47,8 +47,8 @@ model Collage {
 
 model FriendRequest {
   id         String   @id @default(cuid())
-  fromUserId String
-  toUserId   String
+  fromUserId Int
+  toUserId   Int
   status     String // 'pending', 'accepted', 'declined'
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
@@ -62,8 +62,8 @@ model FriendRequest {
 
 model Friendship {
   id        String   @id @default(cuid())
-  userId1   String
-  userId2   String
+  userId1   Int
+  userId2   Int
   createdAt DateTime @default(now())
   user1     User     @relation("User1Friendships", fields: [userId1], references: [id], onDelete: Cascade)
   user2     User     @relation("User2Friendships", fields: [userId2], references: [id], onDelete: Cascade)
@@ -75,7 +75,7 @@ model Friendship {
 
 model GameSession {
   id         String         @id @default(cuid())
-  userId     String
+  userId     Int
   gameType   String // "facial_recognition" | "transition_recognition" | "mirroring"
   difficulty String? // For facial_recognition and mirroring
   level      String? // For transition_recognition
@@ -112,7 +112,7 @@ model Organization {
   description         String?
   status              String                              @default("pending") // 'pending' | 'approved' | 'rejected'
   photoSourceSettings String?                             // JSON: { "ekman": true, "own": true, "synthetic": true }, null = all enabled
-  createdByUserId     String
+  createdByUserId     Int
   createdAt           DateTime                            @default(now())
   memberships         OrganizationMembership[]
   createdBy       User                                @relation(fields: [createdByUserId], references: [id], onDelete: Cascade)
@@ -125,7 +125,7 @@ model Organization {
 model OrganizationMembership {
   id             String       @id @default(cuid())
   organizationId String
-  userId         String
+  userId         Int
   role           String       @default("member") // 'member' | 'org_admin'
   status         String       @default("pending") // 'pending' | 'approved' | 'removed'
   joinedAt       DateTime     @default(now())

--- a/frontend/src/lib/userId.ts
+++ b/frontend/src/lib/userId.ts
@@ -1,30 +1,28 @@
 import { prisma } from './db';
 
+/** Parse string user id (from API/getCurrentUser) to number for Prisma. */
+export function toPrismaUserId(id: string): number {
+  const n = parseInt(id, 10);
+  if (Number.isNaN(n)) throw new Error('Invalid user id');
+  return n;
+}
+
 /**
- * Generate a unique 9-digit numeric user ID
- * Returns as string (since Prisma ID is String type)
+ * Generate a unique numeric user ID (high range to avoid colliding with backend ids 1,2,...).
+ * Returns number to match Prisma User.id (Int).
  */
-export async function generateUserId(): Promise<string> {
+export async function generateUserId(): Promise<number> {
   let attempts = 0;
   const maxAttempts = 100;
-  
   while (attempts < maxAttempts) {
-    // Generate random 9-digit number (100000000 to 999999999)
-    const id = Math.floor(100000000 + Math.random() * 900000000).toString();
-    
-    // Check if ID already exists
+    const id = Math.floor(100000000 + Math.random() * 900000000);
     const existing = await prisma.user.findUnique({
       where: { id },
       select: { id: true }
     });
-    
-    if (!existing) {
-      return id;
-    }
-    
+    if (!existing) return id;
     attempts++;
   }
-  
-  throw new Error('Failed to generate unique 9-digit user ID after ' + maxAttempts + ' attempts');
+  throw new Error('Failed to generate unique user ID after ' + maxAttempts + ' attempts');
 }
 

--- a/frontend/src/lib/utils/syncUser.ts
+++ b/frontend/src/lib/utils/syncUser.ts
@@ -3,36 +3,27 @@
 import { prisma } from '$lib/db';
 import { generateUserId } from '$lib/userId';
 
+/** Return type: id as string for API compatibility. */
 export async function ensurePrismaUser(email: string): Promise<{ id: string; role: string } | null> {
   try {
-    // Normalize email
     const normalizedEmail = email.trim().toLowerCase();
-    
-    // Check if user already exists
     let prismaUser = await prisma.user.findFirst({
       where: { username: normalizedEmail },
       select: { id: true, role: true }
     });
-    
-    // If user exists, return it (but update role if needed for admin)
     if (prismaUser) {
-      // Ensure admin role is set correctly for jonakfir@gmail.com
       if (normalizedEmail === 'jonakfir@gmail.com' && prismaUser.role !== 'admin') {
         await prisma.user.update({
           where: { id: prismaUser.id },
           data: { role: 'admin' }
         });
-        prismaUser.role = 'admin';
+        prismaUser = { ...prismaUser, role: 'admin' };
       }
-      return prismaUser;
+      return { id: String(prismaUser.id), role: prismaUser.role };
     }
-    
-    // User doesn't exist, create them
     const userId = await generateUserId();
     const bcrypt = await import('bcryptjs');
     const defaultPassword = await bcrypt.default.hash('temp', 10);
-    
-    // Generate unique invitation code
     const { randomBytes } = await import('crypto');
     let invitationCode: string | undefined;
     let attempts = 0;
@@ -40,15 +31,12 @@ export async function ensurePrismaUser(email: string): Promise<{ id: string; rol
       invitationCode = randomBytes(8).toString('hex').toUpperCase();
       attempts++;
       if (attempts > 10) {
-        invitationCode = undefined; // Skip if can't generate
+        invitationCode = undefined;
         break;
       }
     } while (await prisma.user.findUnique({ where: { invitationCode } }));
-    
-    // Hardcode admin role for jonakfir@gmail.com
     const isAdmin = normalizedEmail === 'jonakfir@gmail.com';
     const role = isAdmin ? 'admin' : 'personal';
-    
     prismaUser = await prisma.user.create({
       data: {
         id: userId,
@@ -59,8 +47,7 @@ export async function ensurePrismaUser(email: string): Promise<{ id: string; rol
       },
       select: { id: true, role: true }
     });
-    
-    return prismaUser;
+    return { id: String(prismaUser.id), role: prismaUser.role };
   } catch (error: any) {
     console.error('[ensurePrismaUser] Error:', error);
     return null;

--- a/frontend/src/routes/api/admin/analytics/+server.ts
+++ b/frontend/src/routes/api/admin/analytics/+server.ts
@@ -15,13 +15,13 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
       // HARDCODE: jonakfir@gmail.com is ALWAYS admin
       if (email === 'jonakfir@gmail.com') {
         const user = await ensurePrismaUser(email);
-        return user ? { id: user.id, role: 'admin' } : null;
+        return user ? { id: String(user.id), role: 'admin' } : null;
       }
       const user = await prisma.user.findFirst({
         where: { username: email },
         select: { id: true, role: true }
       });
-      if (user) return { id: user.id, role: user.role || 'personal' };
+      if (user) return { id: String(user.id), role: user.role || 'personal' };
       return null;
     }
     
@@ -46,7 +46,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
     const email = (backendUser.email || backendUser.username || '').trim().toLowerCase();
     if (email === 'jonakfir@gmail.com') {
       const user = await ensurePrismaUser(email);
-      return user ? { id: user.id, role: 'admin' } : null;
+      return user ? { id: String(user.id), role: 'admin' } : null;
     }
     
     // For other users, ensure they exist in Prisma

--- a/frontend/src/routes/api/admin/ekman-images/+server.ts
+++ b/frontend/src/routes/api/admin/ekman-images/+server.ts
@@ -1,10 +1,10 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
-    // Check for mock auth headers first (dev mode)
     const mockUserId = event.request.headers.get('X-User-Id');
     const mockUserEmail = event.request.headers.get('X-User-Email');
     if (mockUserId && mockUserEmail) {
@@ -12,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     // Try backend auth with JWT token and cookies
@@ -61,7 +61,7 @@ export const GET: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 
@@ -161,7 +161,7 @@ export const POST: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 
@@ -271,7 +271,7 @@ export const PUT: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 
@@ -319,7 +319,7 @@ export const DELETE: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 

--- a/frontend/src/routes/api/admin/ekman-images/[id]/+server.ts
+++ b/frontend/src/routes/api/admin/ekman-images/[id]/+server.ts
@@ -1,10 +1,10 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
-    // Check for mock auth headers first (dev mode)
     const mockUserId = event.request.headers.get('X-User-Id');
     const mockUserEmail = event.request.headers.get('X-User-Email');
     if (mockUserId && mockUserEmail) {
@@ -12,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     // Try backend auth with JWT token and cookies
@@ -61,7 +61,7 @@ export const DELETE: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 

--- a/frontend/src/routes/api/admin/ekman-images/[id]/visibility/+server.ts
+++ b/frontend/src/routes/api/admin/ekman-images/[id]/visibility/+server.ts
@@ -1,10 +1,10 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
-    // Check for mock auth headers first (dev mode)
     const mockUserId = event.request.headers.get('X-User-Id');
     const mockUserEmail = event.request.headers.get('X-User-Email');
     if (mockUserId && mockUserEmail) {
@@ -12,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     // Try backend auth with JWT token and cookies
@@ -61,7 +61,7 @@ export const PUT: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 

--- a/frontend/src/routes/api/admin/get-user-role/+server.ts
+++ b/frontend/src/routes/api/admin/get-user-role/+server.ts
@@ -32,7 +32,7 @@ export const GET: RequestHandler = async (event) => {
     return json({
       ok: true,
       user: {
-        id: user.id,
+        id: String(user.id),
         username: user.username,
         role: user.role || 'personal'
       }

--- a/frontend/src/routes/api/admin/import-synthetic-images/+server.ts
+++ b/frontend/src/routes/api/admin/import-synthetic-images/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 import { readFile, readdir } from 'fs/promises';
 import { join } from 'path';
 import { randomBytes } from 'crypto';
@@ -14,7 +15,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -59,7 +60,7 @@ export const POST: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
     }
 
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
     

--- a/frontend/src/routes/api/admin/organizations/+server.ts
+++ b/frontend/src/routes/api/admin/organizations/+server.ts
@@ -1,10 +1,10 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
-    // Check for mock auth headers first (dev mode)
     const mockUserId = event.request.headers.get('X-User-Id');
     const mockUserEmail = event.request.headers.get('X-User-Email');
     if (mockUserId && mockUserEmail) {
@@ -12,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     // Try backend auth with JWT token and cookies
@@ -284,7 +284,7 @@ export const POST: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database to ensure it's current
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     console.log('[POST /api/admin/organizations] User role from DB:', me?.role, 'Email:', me?.username);
     
     // Check if user is admin - hardcode jonakfir@gmail.com as always admin

--- a/frontend/src/routes/api/admin/organizations/[orgId]/+server.ts
+++ b/frontend/src/routes/api/admin/organizations/[orgId]/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
@@ -11,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -50,7 +51,7 @@ export const DELETE: RequestHandler = async (event) => {
     }
 
     const me = await prisma.user.findUnique({
-      where: { id: user.id },
+      where: { id: toPrismaUserId(user.id) },
       select: { role: true, username: true }
     });
     const email = (me?.username || '').trim().toLowerCase();

--- a/frontend/src/routes/api/admin/organizations/[orgId]/folders/+server.ts
+++ b/frontend/src/routes/api/admin/organizations/[orgId]/folders/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
@@ -11,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -56,7 +57,7 @@ export const GET: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
     }
 
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
     
@@ -106,7 +107,7 @@ export const POST: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
     }
 
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
     

--- a/frontend/src/routes/api/admin/organizations/[orgId]/members/+server.ts
+++ b/frontend/src/routes/api/admin/organizations/[orgId]/members/+server.ts
@@ -1,5 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
@@ -10,7 +11,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -44,7 +45,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
       where: { username: backendUser.email },
       select: { id: true, role: true }
     });
-    return prismaUser || null;
+    return prismaUser ? { id: String(prismaUser.id), role: prismaUser.role } : null;
   } catch (error) {
     console.error('[getCurrentUser] Error:', error);
     return null;
@@ -68,6 +69,7 @@ export const POST: RequestHandler = async (event) => {
     if (!['add', 'remove'].includes(action) || !userId) {
       return json({ ok: false, error: 'Invalid request. action must be "add" or "remove", userId required' }, { status: 400 });
     }
+    const userIdNum = toPrismaUserId(userId);
 
     // Verify organization exists
     const org = await prisma.organization.findUnique({
@@ -81,7 +83,7 @@ export const POST: RequestHandler = async (event) => {
 
     // Verify user exists
     const targetUser = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: userIdNum },
       select: { id: true, username: true }
     });
 
@@ -92,13 +94,13 @@ export const POST: RequestHandler = async (event) => {
     if (action === 'add') {
       // Check if membership already exists
       const existing = await prisma.organizationMembership.findUnique({
-        where: { organizationId_userId: { organizationId: orgId, userId } }
+        where: { organizationId_userId: { organizationId: orgId, userId: userIdNum } }
       });
 
       if (existing) {
         // Update existing membership to approved
         const updated = await prisma.organizationMembership.update({
-          where: { organizationId_userId: { organizationId: orgId, userId } },
+          where: { organizationId_userId: { organizationId: orgId, userId: userIdNum } },
           data: { status: 'approved' },
           select: {
             id: true,
@@ -129,7 +131,7 @@ export const POST: RequestHandler = async (event) => {
     } else if (action === 'remove') {
       // Remove or mark as removed
       const existing = await prisma.organizationMembership.findUnique({
-        where: { organizationId_userId: { organizationId: orgId, userId } }
+        where: { organizationId_userId: { organizationId: orgId, userId: userIdNum } }
       });
 
       if (!existing) {
@@ -138,7 +140,7 @@ export const POST: RequestHandler = async (event) => {
 
       // Delete the membership
       await prisma.organizationMembership.delete({
-        where: { organizationId_userId: { organizationId: orgId, userId } }
+        where: { organizationId_userId: { organizationId: orgId, userId: userIdNum } }
       });
 
       return json({ ok: true, action: 'removed', userId });

--- a/frontend/src/routes/api/admin/organizations/[orgId]/photo-sources/+server.ts
+++ b/frontend/src/routes/api/admin/organizations/[orgId]/photo-sources/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
@@ -11,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
     const { PUBLIC_API_URL } = await import('$env/static/public');
     const base = (PUBLIC_API_URL || '').replace(/\/$/, '') || 'http://localhost:4000';
@@ -51,7 +52,7 @@ export const GET: RequestHandler = async (event) => {
   try {
     const user = await getCurrentUser(event);
     if (!user) return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
     if (!isAdmin) return json({ ok: false, error: 'Forbidden' }, { status: 403 });
@@ -75,7 +76,7 @@ export const PATCH: RequestHandler = async (event) => {
   try {
     const user = await getCurrentUser(event);
     if (!user) return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
     if (!isAdmin) return json({ ok: false, error: 'Forbidden' }, { status: 403 });

--- a/frontend/src/routes/api/admin/photos/+server.ts
+++ b/frontend/src/routes/api/admin/photos/+server.ts
@@ -1,10 +1,10 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
-    // Check for mock auth headers first (dev mode)
     const mockUserId = event.request.headers.get('X-User-Id');
     const mockUserEmail = event.request.headers.get('X-User-Email');
     if (mockUserId && mockUserEmail) {
@@ -12,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     // Try backend auth with JWT token and cookies
@@ -61,7 +61,7 @@ export const GET: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 

--- a/frontend/src/routes/api/admin/stats/+server.ts
+++ b/frontend/src/routes/api/admin/stats/+server.ts
@@ -16,13 +16,13 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
       // HARDCODE: jonakfir@gmail.com is ALWAYS admin
       if (email === 'jonakfir@gmail.com') {
         const user = await ensurePrismaUser(email);
-        return user ? { id: user.id } : null;
+        return user ? { id: String(user.id) } : null;
       }
       const user = await prisma.user.findFirst({
         where: { username: email },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     
@@ -48,7 +48,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
     const email = (backendUser.email || backendUser.username || '').trim().toLowerCase();
     if (email === 'jonakfir@gmail.com') {
       const user = await ensurePrismaUser(email);
-      return user ? { id: user.id } : null;
+      return user ? { id: String(user.id) } : null;
     }
     
     // For other users, check Prisma role

--- a/frontend/src/routes/api/admin/stats/users/+server.ts
+++ b/frontend/src/routes/api/admin/stats/users/+server.ts
@@ -15,7 +15,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     
@@ -42,7 +42,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
       select: { id: true, role: true }
     });
     
-    if (prismaUser && prismaUser.role === 'admin') return { id: prismaUser.id };
+    if (prismaUser && prismaUser.role === 'admin') return { id: String(prismaUser.id) };
     return null;
   } catch {
     return null;
@@ -107,10 +107,12 @@ export const GET: RequestHandler = async (event) => {
     
     const where: any = {};
     if (search) {
-      where.OR = [
-        { username: { contains: search } },
-        { id: { contains: search } }
-      ];
+      const numericId = /^\d+$/.test(search) ? parseInt(search, 10) : null;
+      if (numericId !== null) {
+        where.id = numericId;
+      } else {
+        where.username = { contains: search };
+      }
     }
     if (dateFrom || dateTo) {
       where.createdAt = {};

--- a/frontend/src/routes/api/admin/stats/users/[userId]/+server.ts
+++ b/frontend/src/routes/api/admin/stats/users/[userId]/+server.ts
@@ -14,7 +14,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     
@@ -55,15 +55,15 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
 export const GET: RequestHandler = async (event) => {
   try {
     // Admin check is handled by route guard - if user reaches this endpoint, they're already verified as admin
-    const userId = event.params.userId;
+    const userIdParam = event.params.userId;
     
-    if (!userId) {
+    if (!userIdParam) {
       return json({ ok: false, error: 'User ID required' }, { status: 400 });
     }
-    
+    const userIdNum = toPrismaUserId(userIdParam);
     // Get user
     const user = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: userIdNum },
       select: {
         id: true,
         username: true,
@@ -81,8 +81,8 @@ export const GET: RequestHandler = async (event) => {
     const friendships = await prisma.friendship.findMany({
       where: {
         OR: [
-          { userId1: userId },
-          { userId2: userId }
+          { userId1: userIdNum },
+          { userId2: userIdNum }
         ]
       },
       include: {
@@ -104,9 +104,9 @@ export const GET: RequestHandler = async (event) => {
     
     // Format friends list (exclude current user, include friend info)
     const friends = friendships.map(friendship => {
-      const friend = friendship.userId1 === userId ? friendship.user2 : friendship.user1;
+      const friend = friendship.userId1 === userIdNum ? friendship.user2 : friendship.user1;
       return {
-        id: friend.id,
+        id: String(friend.id),
         username: friend.username,
         connectedAt: friendship.createdAt
       };
@@ -114,7 +114,7 @@ export const GET: RequestHandler = async (event) => {
     
     // Get user's collages/photos
     const collages = await prisma.collage.findMany({
-      where: { userId },
+      where: { userId: userIdNum },
       orderBy: { createdAt: 'desc' },
       select: {
         id: true,
@@ -145,7 +145,7 @@ export const GET: RequestHandler = async (event) => {
     
     // Get all game sessions for this user
     const sessions = await prisma.gameSession.findMany({
-      where: { userId },
+      where: { userId: userIdNum },
       orderBy: { createdAt: 'desc' },
       include: {
         questions: true

--- a/frontend/src/routes/api/admin/users/+server.ts
+++ b/frontend/src/routes/api/admin/users/+server.ts
@@ -14,13 +14,13 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
       // HARDCODE: jonakfir@gmail.com is ALWAYS admin
       if (email === 'jonakfir@gmail.com') {
         const user = await ensurePrismaUser(email);
-        return user ? { id: user.id } : null;
+        return user ? { id: String(user.id) } : null;
       }
       const user = await prisma.user.findFirst({
         where: { username: email },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
 
@@ -45,12 +45,12 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
     const email = (backendUser.email || backendUser.username || '').trim().toLowerCase();
     if (email === 'jonakfir@gmail.com') {
       const user = await ensurePrismaUser(email);
-      return user ? { id: user.id } : null;
+      return user ? { id: String(user.id) } : null;
     }
 
     // For other users, check Prisma role
     const prismaUser = await ensurePrismaUser(email);
-    if (prismaUser && prismaUser.role === 'admin') return { id: prismaUser.id };
+    if (prismaUser && prismaUser.role === 'admin') return { id: String(prismaUser.id) };
     return null;
   } catch (error) {
     console.error('[getCurrentAdmin] Error:', error);

--- a/frontend/src/routes/api/admin/users/[userId]/+server.ts
+++ b/frontend/src/routes/api/admin/users/[userId]/+server.ts
@@ -11,7 +11,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
 
@@ -48,16 +48,14 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
 export const DELETE: RequestHandler = async (event) => {
   try {
     // Admin check is handled by route guard - if user reaches this endpoint, they're already verified as admin
-    const userId = event.params.userId;
-    if (!userId) return json({ ok: false, error: 'User ID required' }, { status: 400 });
+    const userIdParam = event.params.userId;
+    if (!userIdParam) return json({ ok: false, error: 'User ID required' }, { status: 400 });
+    const userIdNum = toPrismaUserId(userIdParam);
 
-    // Prevent self-delete casually (optional)
-    // if (admin.id === userId) return json({ ok: false, error: "Admins can't delete themselves" }, { status: 400 });
-
-    const user = await prisma.user.findUnique({ where: { id: userId } });
+    const user = await prisma.user.findUnique({ where: { id: userIdNum } });
     if (!user) return json({ ok: false, error: 'User not found' }, { status: 404 });
 
-    await prisma.user.delete({ where: { id: userId } });
+    await prisma.user.delete({ where: { id: userIdNum } });
 
     return json({ ok: true });
   } catch (error: any) {

--- a/frontend/src/routes/api/admin/users/[userId]/access_level/+server.ts
+++ b/frontend/src/routes/api/admin/users/[userId]/access_level/+server.ts
@@ -10,7 +10,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -57,7 +57,7 @@ export const PATCH: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Invalid access level. Must be "pro", "free_trial", or "none"' }, { status: 400 });
     }
     const prismaUser = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: toPrismaUserId(userId) },
       select: { username: true }
     });
     if (!prismaUser) {

--- a/frontend/src/routes/api/admin/users/[userId]/friends/+server.ts
+++ b/frontend/src/routes/api/admin/users/[userId]/friends/+server.ts
@@ -14,7 +14,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     
@@ -54,14 +54,14 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
 export const GET: RequestHandler = async (event) => {
   try {
     // Admin check is handled by route guard - if user reaches this endpoint, they're already verified as admin
-    const userId = event.params.userId;
-    if (!userId) {
+    const userIdParam = event.params.userId;
+    if (!userIdParam) {
       return json({ ok: false, error: 'User ID required' }, { status: 400 });
     }
-    
+    const userIdNum = toPrismaUserId(userIdParam);
     // Verify user exists
     const user = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: userIdNum },
       select: { id: true, username: true }
     });
     
@@ -73,8 +73,8 @@ export const GET: RequestHandler = async (event) => {
     const friendships = await prisma.friendship.findMany({
       where: {
         OR: [
-          { userId1: userId },
-          { userId2: userId }
+          { userId1: userIdNum },
+          { userId2: userIdNum }
         ]
       },
       include: {
@@ -118,30 +118,30 @@ export const GET: RequestHandler = async (event) => {
 export const POST: RequestHandler = async (event) => {
   try {
     // Admin check is handled by route guard - if user reaches this endpoint, they're already verified as admin
-    const userId = event.params.userId;
-    if (!userId) {
+    const userIdParam = event.params.userId;
+    if (!userIdParam) {
       return json({ ok: false, error: 'User ID required' }, { status: 400 });
     }
-    
+    const userIdNum = toPrismaUserId(userIdParam);
     const body = await event.request.json();
     const friendId = body.friendId;
     
     if (!friendId) {
       return json({ ok: false, error: 'Friend ID required' }, { status: 400 });
     }
-    
-    if (userId === friendId) {
+    const friendIdNum = toPrismaUserId(String(friendId));
+    if (userIdNum === friendIdNum) {
       return json({ ok: false, error: 'Cannot add user as their own friend' }, { status: 400 });
     }
     
     // Verify both users exist
     const [user, friend] = await Promise.all([
       prisma.user.findUnique({
-        where: { id: userId },
+        where: { id: userIdNum },
         select: { id: true, username: true }
       }),
       prisma.user.findUnique({
-        where: { id: friendId },
+        where: { id: friendIdNum },
         select: { id: true, username: true }
       })
     ]);
@@ -186,19 +186,19 @@ export const POST: RequestHandler = async (event) => {
     await prisma.friendRequest.deleteMany({
       where: {
         OR: [
-          { fromUserId: userId, toUserId: friendId },
-          { fromUserId: friendId, toUserId: userId }
+          { fromUserId: userIdNum, toUserId: friendIdNum },
+          { fromUserId: friendIdNum, toUserId: userIdNum }
         ]
       }
     });
     
     // Return the friend object (the other user, not the requesting user)
-    const friendUser = friendship.userId1 === userId ? friendship.user2 : friendship.user1;
+    const friendUser = friendship.userId1 === userIdNum ? friendship.user2 : friendship.user1;
     
     return json({
       ok: true,
       friend: {
-        id: friendUser.id,
+        id: String(friendUser.id),
         username: friendUser.username,
         friendshipId: friendship.id,
         createdAt: friendship.createdAt

--- a/frontend/src/routes/api/admin/users/[userId]/friends/[friendId]/+server.ts
+++ b/frontend/src/routes/api/admin/users/[userId]/friends/[friendId]/+server.ts
@@ -14,7 +14,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     

--- a/frontend/src/routes/api/admin/users/[userId]/override-module/+server.ts
+++ b/frontend/src/routes/api/admin/users/[userId]/override-module/+server.ts
@@ -1,5 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentAdmin(event: { request: Request }): Promise<{ id: string } | null> {
   try {
@@ -10,7 +11,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -47,23 +48,25 @@ export const POST: RequestHandler = async (event) => {
     const moduleId = String(body?.moduleId || '').trim();
     if (!moduleId) return json({ ok: false, error: 'moduleId required (e.g. "7" for mirroring)' }, { status: 400 });
 
-    const target = await prisma.user.findUnique({ where: { id: targetUserId } });
+    const targetNumId = toPrismaUserId(targetUserId);
+    const adminNumId = toPrismaUserId(admin.id);
+    const target = await prisma.user.findUnique({ where: { id: targetNumId } });
     if (!target) return json({ ok: false, error: 'User not found' }, { status: 404 });
 
     await prisma.verifiedModuleCompletion.upsert({
       where: {
-        userId_moduleId: { userId: targetUserId, moduleId }
+        userId_moduleId: { userId: targetNumId, moduleId }
       },
       create: {
-        userId: targetUserId,
+        userId: targetNumId,
         moduleId,
         source: 'admin_override',
-        verifiedByUserId: admin.id,
+        verifiedByUserId: adminNumId,
         photoDataUrl: undefined
       },
       update: {
         source: 'admin_override',
-        verifiedByUserId: admin.id,
+        verifiedByUserId: adminNumId,
         photoDataUrl: undefined
       }
     });

--- a/frontend/src/routes/api/admin/users/[userId]/photo-sources/+server.ts
+++ b/frontend/src/routes/api/admin/users/[userId]/photo-sources/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
@@ -11,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
     const { PUBLIC_API_URL } = await import('$env/static/public');
     const base = (PUBLIC_API_URL || '').replace(/\/$/, '') || 'http://localhost:4000';
@@ -51,7 +52,7 @@ export const GET: RequestHandler = async (event) => {
   try {
     const user = await getCurrentUser(event);
     if (!user) return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
     if (!isAdmin) return json({ ok: false, error: 'Forbidden' }, { status: 403 });
@@ -59,7 +60,7 @@ export const GET: RequestHandler = async (event) => {
     const userId = event.params.userId;
     if (!userId) return json({ ok: false, error: 'userId required' }, { status: 400 });
     const target = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: toPrismaUserId(userId) },
       select: { id: true, photoSourceSettings: true }
     });
     if (!target) return json({ ok: false, error: 'User not found' }, { status: 404 });
@@ -75,13 +76,13 @@ export const PATCH: RequestHandler = async (event) => {
   try {
     const user = await getCurrentUser(event);
     if (!user) return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
     if (!isAdmin) return json({ ok: false, error: 'Forbidden' }, { status: 403 });
 
-    const userId = event.params.userId;
-    if (!userId) return json({ ok: false, error: 'userId required' }, { status: 400 });
+    const userIdParam = event.params.userId;
+    if (!userIdParam) return json({ ok: false, error: 'userId required' }, { status: 400 });
     const body = await event.request.json().catch(() => ({}));
     const ekman = typeof body.ekman === 'boolean' ? body.ekman : undefined;
     const own = typeof body.own === 'boolean' ? body.own : undefined;
@@ -90,7 +91,7 @@ export const PATCH: RequestHandler = async (event) => {
       return json({ ok: false, error: 'At least one of ekman, own, synthetic required' }, { status: 400 });
     }
     const target = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: toPrismaUserId(userIdParam) },
       select: { id: true, photoSourceSettings: true }
     });
     if (!target) return json({ ok: false, error: 'User not found' }, { status: 404 });
@@ -101,7 +102,7 @@ export const PATCH: RequestHandler = async (event) => {
       synthetic: synthetic !== undefined ? synthetic : current.synthetic
     };
     await prisma.user.update({
-      where: { id: userId },
+      where: { id: toPrismaUserId(userIdParam) },
       data: { photoSourceSettings: JSON.stringify(next) }
     });
     return json({ ok: true, photoSourceSettings: next });

--- a/frontend/src/routes/api/admin/users/[userId]/role/+server.ts
+++ b/frontend/src/routes/api/admin/users/[userId]/role/+server.ts
@@ -14,7 +14,7 @@ async function getCurrentAdmin(event: { request: Request }): Promise<{ id: strin
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user && user.role === 'admin') return { id: user.id };
+      if (user && user.role === 'admin') return { id: String(user.id) };
       return null;
     }
     
@@ -71,7 +71,7 @@ export const PATCH: RequestHandler = async (event) => {
     // Check if this is the last admin being downgraded
     if (role === 'personal') {
       const currentUser = await prisma.user.findUnique({
-        where: { id: userId },
+        where: { id: toPrismaUserId(userId) },
         select: { role: true }
       });
       
@@ -95,7 +95,7 @@ export const PATCH: RequestHandler = async (event) => {
       
       // Get user email from Prisma to find in backend
       const prismaUser = await prisma.user.findUnique({
-        where: { id: userId },
+        where: { id: toPrismaUserId(userId) },
         select: { username: true }
       });
       
@@ -157,7 +157,7 @@ export const PATCH: RequestHandler = async (event) => {
     
     // SECOND: Update Prisma database (for frontend features)
     const updatedUser = await prisma.user.update({
-      where: { id: userId },
+      where: { id: toPrismaUserId(userId) },
       data: { role },
       select: {
         id: true,

--- a/frontend/src/routes/api/auth/check-user/+server.ts
+++ b/frontend/src/routes/api/auth/check-user/+server.ts
@@ -46,7 +46,7 @@ export const POST: RequestHandler = async (event) => {
       exists: true,
       validPassword: password ? true : undefined,
       user: {
-        id: user.id,
+        id: String(user.id),
         username: user.username,
         role: user.role || 'personal'
       }

--- a/frontend/src/routes/api/collages/+server.ts
+++ b/frontend/src/routes/api/collages/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { prisma } from '$lib/db';
-import { generateUserId } from '$lib/userId';
+import { generateUserId, toPrismaUserId } from '$lib/userId';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
 
 /**
@@ -62,7 +62,7 @@ async function getCurrentUser(event: { request: Request; cookies: any; url: URL;
       }
       
       return {
-        id: prismaUser.id,
+        id: String(prismaUser.id),
         backendId: Number(mockUserId)
       };
     }
@@ -154,7 +154,7 @@ async function getCurrentUser(event: { request: Request; cookies: any; url: URL;
     }
     
     return {
-      id: prismaUser.id,
+      id: String(prismaUser.id),
       backendId: Number(backendUser.id)
     };
   } catch (error: any) {
@@ -258,7 +258,7 @@ export const POST: RequestHandler = async (event) => {
     console.log('[POST /api/collages] Saving collage with userId:', user.id, 'imageUrl length:', dataUrl.length);
     const collage = await prisma.collage.create({
       data: {
-        userId: user.id,
+        userId: toPrismaUserId(user.id),
         imageUrl: dataUrl, // Store as base64 data URL instead of file path
         emotions: emotions ? JSON.stringify(emotions) : null,
         approvedAnyway: approvedAnyway || undefined
@@ -377,7 +377,7 @@ export const GET: RequestHandler = async (event) => {
 
     // Fetch user's collages
     const collages = await prisma.collage.findMany({
-      where: { userId: user.id },
+      where: { userId: toPrismaUserId(user.id) },
       orderBy: { createdAt: 'desc' }
     });
 

--- a/frontend/src/routes/api/collages/[id]/+server.ts
+++ b/frontend/src/routes/api/collages/[id]/+server.ts
@@ -2,7 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 // Lazy load env
 import { prisma } from '$lib/db';
-import { generateUserId } from '$lib/userId';
+import { generateUserId, toPrismaUserId } from '$lib/userId';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
 
 /**
@@ -121,7 +121,7 @@ export const DELETE: RequestHandler = async (event) => {
     }
 
     // Get fresh role from database to ensure it's current
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     console.log('[DELETE /api/collages/[id]] User role from DB:', me?.role, 'Email:', me?.username);
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
@@ -170,7 +170,7 @@ export const PATCH: RequestHandler = async (event) => {
     const user = await getCurrentUser(event);
     if (!user) return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
 
-    const me = await prisma.user.findUnique({ where: { id: user.id }, select: { role: true, username: true } });
+    const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(user.id) }, select: { role: true, username: true } });
     const email = (me?.username || '').trim().toLowerCase();
     const isAdmin = email === 'jonakfir@gmail.com' || me?.role === 'admin';
 

--- a/frontend/src/routes/api/friends/+server.ts
+++ b/frontend/src/routes/api/friends/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 import { generateUserId } from '$lib/userId';
 import { env as publicEnv } from '$env/dynamic/public';
 // Lazy load env
@@ -150,8 +151,9 @@ function generateInvitationCode(): string {
  * Ensure user has an invitation code
  */
 async function ensureInvitationCode(userId: string): Promise<string> {
+  const uidNum = toPrismaUserId(userId);
   let user = await prisma.user.findUnique({
-    where: { id: userId },
+    where: { id: uidNum },
     select: { invitationCode: true }
   });
   
@@ -167,7 +169,7 @@ async function ensureInvitationCode(userId: string): Promise<string> {
     } while (await prisma.user.findUnique({ where: { invitationCode: code } }));
     
     user = await prisma.user.update({
-      where: { id: userId },
+      where: { id: uidNum },
       data: { invitationCode: code },
       select: { invitationCode: true }
     });
@@ -204,12 +206,13 @@ export const GET: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
     }
 
+    const uidNum = toPrismaUserId(user.id);
     // Get friendships where user is either userId1 or userId2
     const friendships = await prisma.friendship.findMany({
       where: {
         OR: [
-          { userId1: user.id },
-          { userId2: user.id }
+          { userId1: uidNum },
+          { userId2: uidNum }
         ]
       },
       include: {
@@ -225,9 +228,9 @@ export const GET: RequestHandler = async (event) => {
 
     // Map to friend objects
     const friends = friendships.map(f => {
-      const friend = f.userId1 === user.id ? f.user2 : f.user1;
+      const friend = f.userId1 === uidNum ? f.user2 : f.user1;
       return {
-        id: friend.id,
+        id: String(friend.id),
         username: friend.username,
         friendshipId: f.id,
         createdAt: f.createdAt

--- a/frontend/src/routes/api/friends/invitation-code/+server.ts
+++ b/frontend/src/routes/api/friends/invitation-code/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { prisma } from '$lib/db';
-import { generateUserId } from '$lib/userId';
+import { generateUserId, toPrismaUserId } from '$lib/userId';
 // Lazy load env
 import { randomBytes } from 'crypto';
 
@@ -61,7 +61,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
             });
           }
           
-          return { id: prismaUser.id };
+          return { id: String(prismaUser.id) };
         }
       }
     } catch {
@@ -89,7 +89,7 @@ export const GET: RequestHandler = async (event) => {
     }
 
     let prismaUser = await prisma.user.findUnique({
-      where: { id: user.id },
+      where: { id: toPrismaUserId(user.id) },
       select: { invitationCode: true }
     });
 
@@ -105,7 +105,7 @@ export const GET: RequestHandler = async (event) => {
       } while (await prisma.user.findUnique({ where: { invitationCode: code } }));
 
       prismaUser = await prisma.user.update({
-        where: { id: user.id },
+        where: { id: toPrismaUserId(user.id) },
         data: { invitationCode: code },
         select: { invitationCode: true }
       });

--- a/frontend/src/routes/api/friends/requests/+server.ts
+++ b/frontend/src/routes/api/friends/requests/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { prisma } from '$lib/db';
-import { generateUserId } from '$lib/userId';
+import { generateUserId, toPrismaUserId } from '$lib/userId';
 import { env as publicEnv } from '$env/dynamic/public';
 
 async function proxyToBackend(path: string, request: Request, init?: RequestInit): Promise<Response> {
@@ -136,7 +136,7 @@ export const GET: RequestHandler = async (event) => {
       // Received requests (pending)
       prisma.friendRequest.findMany({
         where: {
-          toUserId: user.id,
+          toUserId: uid,
           status: 'pending'
         },
         include: {
@@ -239,12 +239,14 @@ export const POST: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Cannot send request to yourself' }, { status: 400 });
     }
 
+    const uidNum = toPrismaUserId(user.id);
+    const targetIdNum = toPrismaUserId(targetUser.id);
     // Check if friendship already exists
     const existingFriendship = await prisma.friendship.findFirst({
       where: {
         OR: [
-          { userId1: user.id, userId2: targetUser.id },
-          { userId1: targetUser.id, userId2: user.id }
+          { userId1: uidNum, userId2: targetIdNum },
+          { userId1: targetIdNum, userId2: uidNum }
         ]
       }
     });
@@ -289,8 +291,8 @@ export const POST: RequestHandler = async (event) => {
     // Check if request already exists
     const existingRequest = await prisma.friendRequest.findFirst({
       where: {
-        fromUserId: user.id,
-        toUserId: targetUser.id,
+        fromUserId: uidNum,
+        toUserId: targetIdNum,
         status: 'pending'
       }
     });
@@ -302,8 +304,8 @@ export const POST: RequestHandler = async (event) => {
     // Create new request
     const request = await prisma.friendRequest.create({
       data: {
-        fromUserId: user.id,
-        toUserId: targetUser.id,
+        fromUserId: uidNum,
+        toUserId: targetIdNum,
         status: 'pending'
       }
     });

--- a/frontend/src/routes/api/friends/requests/[requestId]/+server.ts
+++ b/frontend/src/routes/api/friends/requests/[requestId]/+server.ts
@@ -92,7 +92,8 @@ export const DELETE: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Request not found' }, { status: 404 });
     }
 
-    if (request.fromUserId !== user.id) {
+    const { toPrismaUserId } = await import('$lib/userId');
+    if (request.fromUserId !== toPrismaUserId(user.id)) {
       return json({ ok: false, error: 'Unauthorized' }, { status: 403 });
     }
 

--- a/frontend/src/routes/api/friends/requests/[requestId]/accept/+server.ts
+++ b/frontend/src/routes/api/friends/requests/[requestId]/accept/+server.ts
@@ -118,8 +118,9 @@ export const POST: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Request not found' }, { status: 404 });
     }
 
-    // Verify user is the recipient
-    if (request.toUserId !== user.id) {
+    // Verify user is the recipient (request.toUserId is Int, user.id is string)
+    const { toPrismaUserId } = await import('$lib/userId');
+    if (request.toUserId !== toPrismaUserId(user.id)) {
       return json({ ok: false, error: 'Unauthorized' }, { status: 403 });
     }
 
@@ -128,7 +129,7 @@ export const POST: RequestHandler = async (event) => {
     }
 
     // Create friendship (userId1 < userId2)
-    const [userId1, userId2] = [request.fromUserId, request.toUserId].sort();
+    const [userId1, userId2] = [request.fromUserId, request.toUserId].sort((a, b) => a - b);
 
     await prisma.$transaction([
       prisma.friendship.create({

--- a/frontend/src/routes/api/friends/requests/[requestId]/decline/+server.ts
+++ b/frontend/src/routes/api/friends/requests/[requestId]/decline/+server.ts
@@ -113,7 +113,8 @@ export const POST: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Request not found' }, { status: 404 });
     }
 
-    if (request.toUserId !== user.id) {
+    const { toPrismaUserId } = await import('$lib/userId');
+    if (request.toUserId !== toPrismaUserId(user.id)) {
       return json({ ok: false, error: 'Unauthorized' }, { status: 403 });
     }
 

--- a/frontend/src/routes/api/friends/search/+server.ts
+++ b/frontend/src/routes/api/friends/search/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { prisma } from '$lib/db';
-import { generateUserId } from '$lib/userId';
+import { generateUserId, toPrismaUserId } from '$lib/userId';
 import { env as publicEnv } from '$env/dynamic/public';
 
 async function proxyToBackend(path: string, request: Request, init?: RequestInit): Promise<Response> {
@@ -127,12 +127,13 @@ export const GET: RequestHandler = async (event) => {
     console.log(`[friends/search] Searching for email: "${searchTerm}" or userId: "${searchUserId}"`);
 
     // Get current user's friends and pending requests to exclude
+    const uidNum = toPrismaUserId(user.id);
     const [friendships, sentRequests, receivedRequests] = await Promise.all([
       prisma.friendship.findMany({
         where: {
           OR: [
-            { userId1: user.id },
-            { userId2: user.id }
+            { userId1: uidNum },
+            { userId2: uidNum }
           ]
         },
         select: {
@@ -142,27 +143,27 @@ export const GET: RequestHandler = async (event) => {
       }),
       prisma.friendRequest.findMany({
         where: {
-          fromUserId: user.id,
+          fromUserId: uidNum,
           status: 'pending'
         },
         select: { toUserId: true }
       }),
       prisma.friendRequest.findMany({
         where: {
-          toUserId: user.id,
+          toUserId: uidNum,
           status: 'pending'
         },
         select: { fromUserId: true }
       })
     ]);
 
-    // Collect all user IDs to exclude
+    // Collect all user IDs to exclude (as strings for API)
     const excludeIds = new Set<string>([user.id]);
     friendships.forEach(f => {
-      excludeIds.add(f.userId1 === user.id ? f.userId2 : f.userId1);
+      excludeIds.add(String(f.userId1 === uidNum ? f.userId2 : f.userId1));
     });
-    sentRequests.forEach(r => excludeIds.add(r.toUserId));
-    receivedRequests.forEach(r => excludeIds.add(r.fromUserId));
+    sentRequests.forEach(r => excludeIds.add(String(r.toUserId)));
+    receivedRequests.forEach(r => excludeIds.add(String(r.fromUserId)));
     
     console.log(`[friends/search] Excluding ${excludeIds.size} user IDs:`, Array.from(excludeIds));
     

--- a/frontend/src/routes/api/game-sessions/+server.ts
+++ b/frontend/src/routes/api/game-sessions/+server.ts
@@ -1,5 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 
 /**
  * Get current user from auth (supports both mock and real auth)
@@ -15,7 +16,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true }
       });
-      if (user) return { id: user.id };
+      if (user) return { id: String(user.id) };
     }
     
     // Try real backend auth
@@ -79,7 +80,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
       });
     }
     
-    if (prismaUser) return { id: prismaUser.id };
+    if (prismaUser) return { id: String(prismaUser.id) };
     return null;
   } catch {
     return null;
@@ -123,7 +124,7 @@ export const POST: RequestHandler = async (event) => {
     // Create game session
     const session = await prisma.gameSession.create({
       data: {
-        userId: user.id,
+        userId: toPrismaUserId(user.id),
         gameType,
         difficulty: difficulty || null,
         level: level || null,
@@ -171,7 +172,7 @@ export const GET: RequestHandler = async (event) => {
     const limit = parseInt(url.searchParams.get('limit') || '50', 10);
     const offset = parseInt(url.searchParams.get('offset') || '0', 10);
     
-    const where: any = { userId: user.id };
+    const where: any = { userId: toPrismaUserId(user.id) };
     if (gameType) {
       where.gameType = gameType;
     }

--- a/frontend/src/routes/api/organizations/+server.ts
+++ b/frontend/src/routes/api/organizations/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
 import { ensurePrismaUser } from '$lib/utils/syncUser';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string; role: string } | null> {
   try {
@@ -11,7 +12,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      return user || null;
+      return user ? { id: String(user.id), role: user.role } : null;
     }
 
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -66,7 +67,7 @@ export const GET: RequestHandler = async (event) => {
     let where: any = { status: 'approved' };
     // If admin requests all, do not constrain by status
     if (all && current) {
-      const me = await prisma.user.findUnique({ where: { id: current.id }, select: { role: true } });
+      const me = await prisma.user.findUnique({ where: { id: toPrismaUserId(current.id) }, select: { role: true } });
       if (me?.role === 'admin') {
         where = {};
       }
@@ -74,7 +75,7 @@ export const GET: RequestHandler = async (event) => {
     if (mine && current) {
       try {
         const memberships = await prisma.organizationMembership.findMany({
-          where: { userId: current.id },
+          where: { userId: toPrismaUserId(current.id) },
           select: { organizationId: true }
         });
         const ids = memberships.map(m => m.organizationId);
@@ -141,11 +142,11 @@ export const POST: RequestHandler = async (event) => {
       data: {
         name,
         description,
-        createdByUserId: user.id,
+        createdByUserId: toPrismaUserId(user.id),
         status: 'pending',
         memberships: {
           create: {
-            userId: user.id,
+            userId: toPrismaUserId(user.id),
             role: 'org_admin',
             status: 'pending'
           }

--- a/frontend/src/routes/api/organizations/[orgId]/join/+server.ts
+++ b/frontend/src/routes/api/organizations/[orgId]/join/+server.ts
@@ -1,12 +1,13 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string } | null> {
   try {
     const mockUserEmail = event.request.headers.get('X-User-Email');
     if (mockUserEmail) {
       const user = await prisma.user.findFirst({ where: { username: mockUserEmail.trim().toLowerCase() }, select: { id: true } });
-      return user || null;
+      return user ? { id: String(user.id) } : null;
     }
     const { PUBLIC_API_URL } = await import('$env/static/public');
     const base = (PUBLIC_API_URL || '').replace(/\/$/, '') || 'http://localhost:4000';
@@ -16,7 +17,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
     const email = data?.user?.email;
     if (!email) return null;
     const prismaUser = await prisma.user.findFirst({ where: { username: email }, select: { id: true } });
-    return prismaUser || null;
+    return prismaUser ? { id: String(prismaUser.id) } : null;
   } catch {
     return null;
   }
@@ -35,9 +36,9 @@ export const POST: RequestHandler = async (event) => {
     }
 
     const membership = await prisma.organizationMembership.upsert({
-      where: { organizationId_userId: { organizationId: orgId, userId: user.id } },
+      where: { organizationId_userId: { organizationId: orgId, userId: toPrismaUserId(user.id) } },
       update: { status: 'pending' },
-      create: { organizationId: orgId, userId: user.id, status: 'pending', role: 'member' },
+      create: { organizationId: orgId, userId: toPrismaUserId(user.id), status: 'pending', role: 'member' },
       select: { id: true, status: true }
     });
 

--- a/frontend/src/routes/api/sync-user/+server.ts
+++ b/frontend/src/routes/api/sync-user/+server.ts
@@ -76,7 +76,7 @@ export const POST: RequestHandler = async (event) => {
     return json({
       ok: true,
       user: {
-        id: prismaUser.id,
+        id: String(prismaUser.id),
         username: prismaUser.username,
         invitationCode: prismaUser.invitationCode
       }

--- a/frontend/src/routes/api/user/org-status/+server.ts
+++ b/frontend/src/routes/api/user/org-status/+server.ts
@@ -1,5 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string } | null> {
   try {
@@ -10,7 +11,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true }
       });
-      return user || null;
+      return user ? { id: String(user.id) } : null;
     }
 
     const { PUBLIC_API_URL } = await import('$env/static/public');
@@ -28,7 +29,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
       where: { username: backendUser.email },
       select: { id: true }
     });
-    return prismaUser || null;
+    return prismaUser ? { id: String(prismaUser.id) } : null;
   } catch {
     return null;
   }
@@ -45,7 +46,7 @@ export const GET: RequestHandler = async (event) => {
     // Find all approved org_admin memberships for this user
     const memberships = await prisma.organizationMembership.findMany({
       where: {
-        userId: user.id,
+        userId: toPrismaUserId(user.id),
         role: 'org_admin',
         status: 'approved'
       },

--- a/frontend/src/routes/api/user/progress/+server.ts
+++ b/frontend/src/routes/api/user/progress/+server.ts
@@ -1,18 +1,19 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string } | null> {
-  // Get user from session cookie
   const cookies = event.request.headers.get('cookie') || '';
   const sessionMatch = cookies.match(/session=([^;]+)/);
   if (!sessionMatch) return null;
 
   try {
-    // Lazy load prisma to avoid blocking startup
     const { prisma } = await import('$lib/prisma');
     const userId = sessionMatch[1];
-    const user = await prisma.user.findUnique({ where: { id: userId } });
-    return user ? { id: user.id } : null;
+    const numId = /^\d+$/.test(userId) ? parseInt(userId, 10) : NaN;
+    if (Number.isNaN(numId)) return null;
+    const user = await prisma.user.findUnique({ where: { id: numId } });
+    return user ? { id: String(user.id) } : null;
   } catch {
     return null;
   }
@@ -30,7 +31,7 @@ export const GET: RequestHandler = async (event) => {
     
     // Get user's game sessions to calculate progress
     const sessions = await prisma.gameSession.findMany({
-      where: { userId: user.id },
+      where: { userId: toPrismaUserId(user.id) },
       select: { gameType: true, score: true, total: true }
     });
 

--- a/frontend/src/routes/api/user/self-override-module/+server.ts
+++ b/frontend/src/routes/api/user/self-override-module/+server.ts
@@ -1,5 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 
 type UserWithRole = { id: string; role: string };
 type DbError = { _dbError: true };
@@ -13,7 +14,7 @@ async function getCurrentUserWithRole(event: { request: Request }): Promise<User
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true, role: true }
       });
-      if (user) return user;
+      if (user) return { id: String(user.id), role: user.role };
     }
     const { PUBLIC_API_URL } = await import('$env/static/public');
     const base = (PUBLIC_API_URL || '').replace(/\/$/, '') || 'http://localhost:4000';
@@ -35,7 +36,7 @@ async function getCurrentUserWithRole(event: { request: Request }): Promise<User
     if (!prismaUser) return null;
     // Use backend role for admin check (backend is source of truth for auth)
     const role = (backendUser.role || prismaUser.role || 'personal').toString().trim();
-    return { id: prismaUser.id, role };
+    return { id: String(prismaUser.id), role };
   } catch (e: any) {
     const msg = (e?.message || '').toLowerCase();
     if (msg.includes("can't reach") || msg.includes('database server') || msg.includes('connection')) {
@@ -61,20 +62,21 @@ export const POST: RequestHandler = async (event) => {
     const moduleId = String(body?.moduleId || '').trim();
     if (!moduleId) return json({ ok: false, error: 'moduleId required (e.g. "7" for mirroring)' }, { status: 400 });
 
+    const uid = toPrismaUserId(user.id);
     await prisma.verifiedModuleCompletion.upsert({
       where: {
-        userId_moduleId: { userId: user.id, moduleId }
+        userId_moduleId: { userId: uid, moduleId }
       },
       create: {
-        userId: user.id,
+        userId: uid,
         moduleId,
         source: 'admin_override',
-        verifiedByUserId: user.id,
+        verifiedByUserId: uid,
         photoDataUrl: undefined
       },
       update: {
         source: 'admin_override',
-        verifiedByUserId: user.id,
+        verifiedByUserId: uid,
         photoDataUrl: undefined
       }
     });

--- a/frontend/src/routes/api/user/verified-module/+server.ts
+++ b/frontend/src/routes/api/user/verified-module/+server.ts
@@ -1,5 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
+import { toPrismaUserId } from '$lib/userId';
 
 async function getCurrentUser(event: { request: Request }): Promise<{ id: string } | null> {
   try {
@@ -10,7 +11,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
         where: { username: mockUserEmail.trim().toLowerCase() },
         select: { id: true }
       });
-      if (user) return user;
+      if (user) return { id: String(user.id) };
     }
     const { PUBLIC_API_URL } = await import('$env/static/public');
     const base = (PUBLIC_API_URL || '').replace(/\/$/, '') || 'http://localhost:4000';
@@ -29,7 +30,7 @@ async function getCurrentUser(event: { request: Request }): Promise<{ id: string
       where: { username: email },
       select: { id: true }
     });
-    return prismaUser ? { id: prismaUser.id } : null;
+    return prismaUser ? { id: String(prismaUser.id) } : null;
   } catch {
     return null;
   }
@@ -48,12 +49,13 @@ export const POST: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Invalid or disallowed moduleId. Use 7 for mirroring.' }, { status: 400 });
     }
     const photoDataUrl = body.photoDataUrl != null ? String(body.photoDataUrl) : null;
+    const uid = toPrismaUserId(user.id);
     await prisma.verifiedModuleCompletion.upsert({
       where: {
-        userId_moduleId: { userId: user.id, moduleId }
+        userId_moduleId: { userId: uid, moduleId }
       },
       create: {
-        userId: user.id,
+        userId: uid,
         moduleId,
         source: 'photo',
         photoDataUrl: photoDataUrl || undefined,

--- a/frontend/src/routes/ekman/+server.ts
+++ b/frontend/src/routes/ekman/+server.ts
@@ -1,7 +1,7 @@
 // src/routes/ekman/+server.ts
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { prisma } from '$lib/db';
-import { generateUserId } from '$lib/userId';
+import { generateUserId, toPrismaUserId } from '$lib/userId';
 import { PUBLIC_API_URL } from '$env/static/public';
 
 const EMOTIONS = ['Anger', 'Disgust', 'Fear', 'Happy', 'Neutral', 'Sad', 'Surprise'];
@@ -22,7 +22,7 @@ async function getUserCollages(userId: string | null): Promise<Array<{ img: stri
   
   try {
     const collages = await prisma.collage.findMany({
-      where: { userId },
+      where: { userId: toPrismaUserId(userId) },
       select: {
         imageUrl: true,
         emotions: true
@@ -270,7 +270,7 @@ async function getEffectivePhotoSourceSettings(userId: string | null): Promise<{
   if (!userId) return defaults;
   try {
     const user = await prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: toPrismaUserId(userId) },
       select: { photoSourceSettings: true }
     });
     let effective = parsePhotoSourceSettings(user?.photoSourceSettings ?? null);


### PR DESCRIPTION
- generateUserId returns number; ensurePrismaUser creates with numeric id, returns string id for API
- Add toPrismaUserId() for all Prisma where id / userId using current user
- Admin stats users: search by numeric id or username (remove id contains)
- Normalize getCurrentUser returns to { id: string } across admin, org, collages, game-sessions, friends, user modules