### PR TITLE
Force IPv4 DNS resolution order for Postgres

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,5 @@
 // backend/server.js
+require('dns').setDefaultResultOrder('ipv4first');
 require('dotenv').config();
 
 const express = require('express');


### PR DESCRIPTION
Prefer IPv4 over IPv6 in Node DNS lookups to avoid Railway internal Postgres connection failures resolving to unreachable IPv6 addresses.